### PR TITLE
Adding composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+  "name": "comeetco/comeet-wp-plugin",
+  "description": "Official Comeet plugin for integrating job listings into WordPress.",
+  "type": "wordpress-plugin",
+  "license": "Apache-2.0",
+  "authors": [
+    {
+      "name": "Comeet",
+      "homepage": "https://www.comeet.com"
+    }
+  ],
+  "require": {
+    "php": ">=5.6"
+  }
+}


### PR DESCRIPTION
Adding a `composer.json` to your plugin will make it a "Composer-installable" package. This allows for easy installation via tools like [composer/installers](https://github.com/composer/installers) or [Bedrock](https://roots.io/bedrock/).